### PR TITLE
Build armhf .deb as well as amd64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - run:
           name: Install qemu-arm-static
-          command: sudo apt-get update && apt-get install -y qemu-user-static
+          command: sudo apt-get update && sudo apt-get install -y qemu-user-static
       - checkout
       - run:
           name: Start armhf container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,12 @@ version: 2.1
 jobs:
   build-amd64:
     docker:
-      - image: debian:stretch
+      - image: minimsecure/circleci-debian-amd64:stretch-slim
     steps:
-      - run:
-          name: Install build dependencies
-          command: apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper
       - checkout
       - run:
-          name: Build unum
+          name: Build unum and .deb
           command: ./dist/make_dotdeb.sh "$CIRCLE_TAG"
-      - run:
-          name: Copy .deb to out directory
-          command: cp -f ../unum-*.deb out/linux_generic
       - store_artifacts:
           path: out/linux_generic
           destination: build
@@ -22,18 +16,22 @@ jobs:
     steps:
       - run:
           name: Install qemu-arm-static
-          command: sudo apt-get update && sudo apt-get install -y qemu-user-static
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
       - checkout
       - run:
-          name: Start armhf container
-          command: docker run -v "$PWD:/root/unum-sdk" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
-      - run:
-          name: Build unum
+          name: Start armhf build container
           command: |
-            docker exec -t builder /bin/bash -c 'apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper'
-            docker exec -t builder /bin/bash -c 'cd /root/unum-sdk
-            ./dist/make_dotdeb.sh "$CIRCLE_TAG"
-            cp -f ../unum-*.deb out/linux_generic'
+            docker run -v "$PWD:/root/unum-sdk" \
+              -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static \
+              --rm --name builder -dti minimsecure/circleci-debian-armhf:stretch-slim
+      - run:
+          name: Build unum and .deb
+          command: |
+            docker exec -t builder /bin/bash -c \
+              'cd /root/unum-sdk
+              ./dist/make_dotdeb.sh "$CIRCLE_TAG"'
       - store_artifacts:
           path: out/linux_generic
           destination: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - run:
           name: Build unum
           command: |
-            docker exec -t builder /bin/bash -c 'apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper
-            cd /root/unum-sdk
+            docker exec -t builder /bin/bash -c 'apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper'
+            docker exec -t builder /bin/bash -c 'cd /root/unum-sdk
             ./dist/make_dotdeb.sh "$CIRCLE_TAG"
             cp -f ../unum-*.deb out/linux_generic'
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,12 @@ jobs:
       - checkout
       - run:
           name: Start armhf container
-          command: docker run -v "$PWD:/root" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
+          command: docker run -v "$PWD:/root/unum-sdk" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
       - run:
           name: Build unum
           command: |
             docker exec -t builder /bin/bash -c 'apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper
+            cd /root/unum-sdk
             ./dist/make_dotdeb.sh "$CIRCLE_TAG"
             cp -f ../unum-*.deb out/linux_generic'
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run:
           name: Start armhf container
-          command: docker run -v 'project:.' -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
+          command: docker run -v "$PWD:/root" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
       - run:
           name: Build unum
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2.1
 jobs:
-  build:
+  build-amd64:
     docker:
       - image: debian:stretch
-    working_directory: /usr/local/src/unum
     steps:
       - run:
           name: Install build dependencies
@@ -15,6 +14,25 @@ jobs:
       - run:
           name: Copy .deb to out directory
           command: cp -f ../unum-*.deb out/linux_generic
+      - store_artifacts:
+          path: out/linux_generic
+          destination: build
+  build-armhf:
+    machine: true
+    steps:
+      - run:
+          name: Install qemu-arm-static
+          command: sudo apt-get update && apt-get install -y qemu-user-static
+      - checkout
+      - run:
+          name: Start armhf container
+          command: docker run -v 'project:.' -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static --rm --name builder -dti arm32v7/debian:stretch-slim
+      - run:
+          name: Build unum
+          command: |
+            docker exec -t builder /bin/bash -c 'apt-get update && apt-get install -y build-essential git libcurl4-openssl-dev libjansson-dev libnl-3-dev libnl-genl-3-dev debhelper
+            ./dist/make_dotdeb.sh "$CIRCLE_TAG"
+            cp -f ../unum-*.deb out/linux_generic'
       - store_artifacts:
           path: out/linux_generic
           destination: build
@@ -71,7 +89,8 @@ workflows:
   version: 2
   snapshot:
     jobs:
-      - build
+      - build-amd64
+      - build-armhf
       - build-docker
       - publish-docker:
           requires:
@@ -81,7 +100,13 @@ workflows:
               only: master
   release:
     jobs:
-      - build:
+      - build-amd64:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - build-armhf:
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/debian-amd64/Dockerfile
+++ b/.circleci/debian-amd64/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stretch-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        git \
+        libcurl4-openssl-dev \
+        libjansson-dev \
+        libnl-3-dev \
+        libnl-genl-3-dev \
+        debhelper

--- a/.circleci/debian-armhf/Dockerfile
+++ b/.circleci/debian-armhf/Dockerfile
@@ -1,0 +1,11 @@
+FROM arm32v7/debian:stretch-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        git \
+        libcurl4-openssl-dev \
+        libjansson-dev \
+        libnl-3-dev \
+        libnl-genl-3-dev \
+        debhelper

--- a/dist/make_dotdeb.sh
+++ b/dist/make_dotdeb.sh
@@ -4,6 +4,24 @@ set -eo pipefail
 WORKING_DIR=$(dirname $(readlink -e "$BASH_SOURCE"))
 BUILD_ROOT=$(readlink -e "$WORKING_DIR/..")
 
+declare -i OPT_NO_CLEAN=
+declare -i OPT_ENTER_WORKSPACE=
+
+for arg in $@; do
+    case "$arg" in
+        --no-clean|-C)
+            OPT_NO_CLEAN=1
+            shift
+            ;;
+        --enter-workspace|-X)
+            OPT_ENTER_WORKSPACE=1
+            shift
+            ;;
+        *)  break
+            ;;
+    esac
+done
+
 VERSION_BASE="2018.1.1"
 VERSION_STABILITY="unstable"
 VERSION=${1:-"${VERSION_BASE}-snapshot"}
@@ -20,5 +38,11 @@ fi
 ln -sf "$WORKING_DIR/debian" "$BUILD_ROOT/debian"
 trap "rm -f \"$BUILD_ROOT\"/debian; trap - EXIT" EXIT
 
-dh clean
-dh binary-arch
+if (( OPT_ENTER_WORKSPACE )); then
+    bash -l
+else
+    if ! (( OPT_NO_CLEAN )); then
+        dh clean
+    fi
+    dh binary-arch
+fi

--- a/dist/make_dotdeb.sh
+++ b/dist/make_dotdeb.sh
@@ -45,4 +45,5 @@ else
         dh clean
     fi
     dh binary-arch
+    cp -fv ../unum-aio*.deb out/linux_generic
 fi

--- a/src/iwinfo/Makefile
+++ b/src/iwinfo/Makefile
@@ -33,7 +33,7 @@ clean:
 	rm -rf $(SOURCE_PATH)
 
 $(SOURCE_PATH):
-	git clone $(REPO_URL) $(SOURCE_PATH)
+	git clone --depth=1 $(REPO_URL) $(SOURCE_PATH)
 
 .configured: $(SOURCE_PATH)
 	touch $@


### PR DESCRIPTION
This uses `qemu-arm-static` to build unum natively on armhf.