### PR TITLE
Use actual MAC address as default value in config_interfaces.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: Push docker images
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker push "minimsecure/unum-builder:$DOCKER_TAG"
             docker push "minimsecure/unum:$DOCKER_TAG"
 workflows:

--- a/extras/linux_generic/sbin/config_interfaces.sh
+++ b/extras/linux_generic/sbin/config_interfaces.sh
@@ -49,7 +49,10 @@ prompt_require "Specify WAN network interface" "$ifname_wan"
 ifname_wan="$prompt_val"
 
 hwaddr_lan_orig="$hwaddr_lan"
-prompt_require "Enter MAC address for the LAN interface" "$hwaddr_lan" prompt_validator_macaddr
+if [[ -z "$hwaddr_lan_orig" ]]; then
+    hwaddr_lan_orig=$(ip addr show "$ifname_lan" | awk '/ether / { print $2 }')
+fi
+prompt_require "Enter MAC address for the LAN interface" "$hwaddr_lan_orig" prompt_validator_macaddr
 hwaddr_lan="$prompt_val"
 
 # Between 0 and 255, used as the third octet in LAN IP addresses

--- a/rules/linux_generic.mk
+++ b/rules/linux_generic.mk
@@ -22,8 +22,7 @@ TARGET_RFS_DIST := $(TARGET_RFS)/dist
 TARGET_RFS_ETC := /etc/opt/unum
 TARGET_RFS_VAR := /var/opt/unum
 
-INSTALL_EXTRAS ?= yes
-INSTALL_EXTRAS := $(subst no,,$(INSTALL_EXTRAS))
+INSTALL_EXTRAS ?= 1
 
 ####################################################################
 # Common platform build options                                    #
@@ -53,7 +52,7 @@ TARGET_LIST := iwinfo unum
 TARGET_INSTALL_LIST := $(TARGET_LIST) files
 
 # Include "extras", a collection of utilities for common platforms.
-ifneq ($(filter-out no n,$(INSTALL_EXTRAS)),)
+ifneq ($(filter-out no n 0,$(INSTALL_EXTRAS)),)
 	TARGET_INSTALL_LIST += extras
 endif
 


### PR DESCRIPTION
This PR changes the `config_interfaces.sh` extras script so that it uses the actual LAN interface MAC address as the default, initial value.

Also fixes a warning the circle CI config related to docker login, and makes a small consistency change for the INSTALL_EXTRAS build option.