### PR TITLE
Use minim-config and unum-aio when installing in docker

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /usr/local/src/unum/out/linux_generic/* .
 RUN mkdir -p /opt/unum && \
     tar -C /opt/unum -xf /root/linux_generic*
 
-RUN bash /opt/unum/extras/install.sh --no-interactive --extras --profile
+RUN bash /opt/unum/extras/install.sh --no-interactive --extras --aio --profile && \
+    echo 'service_type="manual"' >> /opt/unum/.installed
 
 RUN sed -i -e 's:wlan0:eth2:' -e 's:eth0:eth1:' /etc/opt/unum/config.json

--- a/extras/docker/docker_build.sh
+++ b/extras/docker/docker_build.sh
@@ -145,6 +145,6 @@ echo "  1. Sign up for a Minim Labs developer account on the Minim website"
 echo "     at https://my.minim.co/labs"
 echo
 echo "  2. Configure and start all services, including Unum:"
-echo "         startup.sh"
+echo "         minim-config"
 echo
 exec docker exec --interactive --tty "$container_name" /bin/bash -l

--- a/extras/linux_generic/sbin/minim-config
+++ b/extras/linux_generic/sbin/minim-config
@@ -44,40 +44,60 @@ usage() {
     fi
 }
 
-# Init system type (eg. systemd)
-declare -r service_type=systemd
+# Init system type (eg. systemd or manual)
+service_type="${service_type:-systemd}"
 # IP related commands (eg. iproute2 or ifconfig)
-declare -r iputils_type=iproute2
+iputils_type="${iputils_type:-iproute2}"
+
+# Prints all pids with command names that match the given input
+# Usage: pids_by_name <name>
+pids_by_name() {
+    echo $(ps axco pid,command | grep $1 | awk 'ORS=" " { print $1 }')
+    return 0
+}
 
 # Start the given service(s)
 # Delegates to a service_type implementation.
 # Usage: start_service <service> [service2 [service3 ...]]
 start_service() {
-    "start_service__$service_type" $@
+    for s in $@; do
+        "start_service__$service_type" "$s" >> "$log_file" 2>&1
+    done
 }
 # Stop the given service(s)
 # Delegates to a service_type implementation.
 # Usage: stop_service <service> [service2 [service3 ...]]
 stop_service() {
-    "stop_service__$service_type" $@
+    for s in $@; do
+        "stop_service__$service_type" "$s" >> "$log_file" 2>&1
+    done
+    # Make doubly-sure that none of these are running
+    local pids=$(pids_by_name $@)
+    for pid in $pids; do
+        kill -9 "$pid"
+    done
 }
 # Disable start on boot for the given service(s)
 # Delegates to a service_type implementation.
 # Usage: disable_service <service> [service2 [service3 ...]]
 disable_service() {
-    "disable_service__$service_type" $@
+    for s in $@; do
+        "disable_service__$service_type" "$s" >> "$log_file" 2>&1
+    done
 }
 # Disable start on boot for the given service(s)
 # Delegates to a service_type implementation.
 # Usage: enable_service <service> [service2 [service3 ...]]
 enable_service() {
-    "enable_service__$service_type" $@
+    for s in $@; do
+        "enable_service__$service_type" "$s" >> "$log_file" 2>&1
+    done
 }
 # Return true or false if the service given appears to be running.
 # Delegates to a service_type implementation.
 # Usage: seems_to_be_running <service>
 seems_to_be_running() {
-    "seems_to_be_running__$service_type" $@
+    "seems_to_be_running__$service_type" $@ >> "$log_file" 2>&1
     return $?
 }
 
@@ -85,34 +105,51 @@ seems_to_be_running() {
 # Delegates to a iputils_type implementation.
 # Usage: set_mac_address <ifname> <hwaddr>
 set_mac_address() {
-    "set_mac_address__$iputils_type" $@
+    "set_mac_address__$iputils_type" $@ >> "$log_file" 2>&1
 }
 
 # Actual implementations for service_type "systemd"
 enable_service__systemd() {
-    for s in $@; do
-        systemctl enable "$s" >> "$log_file" 2>&1
-    done
+    systemctl enable "$1"
 }
 disable_service__systemd() {
-    for s in $@; do
-        systemctl disable "$s" >> "$log_file" 2>&1
-    done
+    systemctl disable "$1"
 }
 start_service__systemd() {
-    for s in $@; do
-        service "$s" start >> "$log_file" 2>&1
-    done
+    service "$1" start
 }
 stop_service__systemd() {
-    for s in $@; do
-        service "$s" stop >> "$log_file" 2>&1
-    done
-    # Make doubly-sure that none of these are running
-    killall -9 $@ >> "$log_file" 2>&1
+    service "$1" stop
 }
 seems_to_be_running__systemd() {
     local chk=$(service "$1" status | grep "active (running)")
+    if [[ -z "$chk" ]]; then
+        return 1
+    fi
+    return 0
+}
+# Actual implementations for service_type "manual"
+enable_service__manual() {
+    echo "notice: manual init option enabled. ignoring enable service command for '$1'"
+    return 0
+}
+disable_service__manual() {
+    echo "notice: manual init option enabled. ignoring disable service command for '$1'"
+    return 0
+}
+start_service__manual() {
+    "start_$1.sh"
+    return $?
+}
+stop_service__manual() {
+    local pids=$(pids_by_name "$1")
+    for pid in $pids; do
+        kill "$pid"
+    done
+    return $?
+}
+seems_to_be_running__manual() {
+    local chk=$(pids_by_name "$1")
     if [[ -z "$chk" ]]; then
         return 1
     fi


### PR DESCRIPTION
This PR modifies the bundled dockerized build to support the `minim-config` utility. It makes use of the previous work toward making `minim-config` work for and adds a "manual" service type as an alternative to "systemd".

Expecting to merge this prior to 2019.1.0 release