### PR TITLE
Fix version handling in CircleCI and Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
               BUILD_VERSION=${CIRCLE_TAG/v/}
             fi
             docker exec -t builder /bin/bash -c \
-              'cd /root/unum-sdk
-              ./dist/make_dotdeb.sh $BUILD_VERSION
+              "cd /root/unum-sdk
+              ./dist/make_dotdeb.sh $BUILD_VERSION"
       - store_artifacts:
           path: out/linux_generic
           destination: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,11 @@ jobs:
       - checkout
       - run:
           name: Build unum and .deb
-          command: ./dist/make_dotdeb.sh "$CIRCLE_TAG"
+          command: |
+            if [[ ! -z "$CIRCLE_TAG" ]]; then
+              BUILD_VERSION=${CIRCLE_TAG/v/}
+            fi
+            ./dist/make_dotdeb.sh $BUILD_VERSION
       - store_artifacts:
           path: out/linux_generic
           destination: build
@@ -32,9 +36,12 @@ jobs:
       - run:
           name: Build unum and .deb
           command: |
+            if [[ ! -z "$CIRCLE_TAG" ]]; then
+              BUILD_VERSION=${CIRCLE_TAG/v/}
+            fi
             docker exec -t builder /bin/bash -c \
               'cd /root/unum-sdk
-              ./dist/make_dotdeb.sh "$CIRCLE_TAG"'
+              ./dist/make_dotdeb.sh $BUILD_VERSION
       - store_artifacts:
           path: out/linux_generic
           destination: build
@@ -52,7 +59,13 @@ jobs:
           name: Build unum-builder image
           command: |
             ln -sf $(readlink -e extras/docker/dockerignore) .dockerignore
-            docker image build --file extras/docker/Dockerfile.build --tag "minimsecure/unum-builder:$DOCKER_TAG" .
+            if [[ ! -z "$CIRCLE_TAG" ]]; then
+              BUILD_VERSION=${CIRCLE_TAG/v/}
+            fi
+            if [[ ! -z "$BUILD_VERSION" ]]; then
+              BUILD_ARG_OPT="--build-arg unum_version=$BUILD_VERSION"
+            fi
+            docker image build --file extras/docker/Dockerfile.build $BUILD_ARG_OPT --tag "minimsecure/unum-builder:$DOCKER_TAG" .
             mkdir -p out
             docker image save -o out/unum-builder_$DOCKER_TAG.dockerimg "minimsecure/unum-builder:$DOCKER_TAG"
       - run:

--- a/extras/docker/Dockerfile.build
+++ b/extras/docker/Dockerfile.build
@@ -1,4 +1,5 @@
 FROM ubuntu:16.04
+ARG unum_version=2019.1.0-snapshot
 
 RUN apt-get update && \
     apt-get install -y \
@@ -14,4 +15,4 @@ RUN apt-get update && \
 WORKDIR /usr/local/src/unum
 COPY . .
 
-RUN make MODEL=linux_generic
+RUN make MODEL=linux_generic AGENT_VERSION=${unum_version}


### PR DESCRIPTION
This PR fixes removes the leading "v" from the agent version in CircleCI builds. It also adds the ability to specify a version in the unum-builder Dockerfile.
