### PR TITLE
Set CircleCI config version to 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 jobs:
   # Build a .deb package for amd64 platforms.
   build-amd64:


### PR DESCRIPTION
Using version 2.1 of CircleCI's config has some drawbacks (mainly I'd like to be able to run individual jobs with parameters) and it isn't actually necessary to use 2.1 for this repo.

This PR switches the circle ci config version to version 2