### PR TITLE
Upstream updates

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
         wireless-tools
 
 WORKDIR /root/
-COPY --from=build /usr/local/src/unum/out/linux_generic/* .
+COPY --from=build /usr/local/src/unum/out/linux_generic/linux_generic* .
 
 RUN mkdir -p /opt/unum && \
     tar -C /opt/unum -xf /root/linux_generic*

--- a/extras/docker/Dockerfile.build
+++ b/extras/docker/Dockerfile.build
@@ -5,6 +5,7 @@ RUN apt-get update && \
     apt-get install -y \
         build-essential \
         gawk \
+        gettext \
         git \
         libcurl4-openssl-dev \
         libjansson-dev \

--- a/extras/docker/dockerignore
+++ b/extras/docker/dockerignore
@@ -8,6 +8,9 @@ rules
 files
 !files/ca/*
 !files/linux_generic/*
+!files/features-common.txt
+!files/features.txt
+!files/release_properties.json
 extras
 !extras/linux_generic/*
 src

--- a/files/features-common.txt
+++ b/files/features-common.txt
@@ -1,0 +1,6 @@
+http-basic-auth-passwords
+telnet-passwords
+rescan_devices
+port_scanning
+speed_test
+ping-flood-release

--- a/files/release_properties.json
+++ b/files/release_properties.json
@@ -1,0 +1,3 @@
+{
+  "feature_names": [ $RELEASE_FEATURES ]
+}

--- a/src/unum/cmdproc/cmdproc.c
+++ b/src/unum/cmdproc/cmdproc.c
@@ -72,6 +72,9 @@ static CMD_RULE_t cmd_gen_rules[] = {
     { "fetch_urls", // fetch URLs requested by the server
       CMD_RULE_M_FULL | CMD_RULE_F_DATA,
       { .act_data = cmd_fetch_urls }},
+    { "force_fw_update", // Force FW update (even for development versions)
+      CMD_RULE_M_FULL | CMD_RULE_F_VOID,
+      { .act_void = cmd_force_fw_update }},
     // CMD_RULE_M_ANY must be the last one
     { "shell_cmd", // generic commands, pass to shell
       CMD_RULE_M_ANY | CMD_RULE_F_DATA,

--- a/src/unum/cmdproc/cmdproc.c
+++ b/src/unum/cmdproc/cmdproc.c
@@ -75,6 +75,11 @@ static CMD_RULE_t cmd_gen_rules[] = {
     { "force_fw_update", // Force FW update (even for development versions)
       CMD_RULE_M_FULL | CMD_RULE_F_VOID,
       { .act_void = cmd_force_fw_update }},
+#ifdef DEBUG
+    { "crash_me",        // Trigger a crash for debugging
+      CMD_RULE_M_FULL | CMD_RULE_F_VOID,
+      { .act_void = NULL }},
+#endif // !DEBUG
     // CMD_RULE_M_ANY must be the last one
     { "shell_cmd", // generic commands, pass to shell
       CMD_RULE_M_ANY | CMD_RULE_F_DATA,

--- a/src/unum/cmdproc/cmdproc.c
+++ b/src/unum/cmdproc/cmdproc.c
@@ -72,9 +72,11 @@ static CMD_RULE_t cmd_gen_rules[] = {
     { "fetch_urls", // fetch URLs requested by the server
       CMD_RULE_M_FULL | CMD_RULE_F_DATA,
       { .act_data = cmd_fetch_urls }},
+#ifdef FW_UPDATER_OPMODE
     { "force_fw_update", // Force FW update (even for development versions)
       CMD_RULE_M_FULL | CMD_RULE_F_VOID,
       { .act_void = cmd_force_fw_update }},
+#endif // FW_UPDATER_OPMODE
 #ifdef DEBUG
     { "crash_me",        // Trigger a crash for debugging
       CMD_RULE_M_FULL | CMD_RULE_F_VOID,

--- a/src/unum/fw_update/linux_generic/fw_update.h
+++ b/src/unum/fw_update/linux_generic/fw_update.h
@@ -17,6 +17,8 @@
 #ifndef _FW_UPDATE_H
 #define _FW_UPDATE_H
 
+// this module is not implemented for linux_generic
+
 #define FW_UPDATE_CHECK_PERIOD 0
 
 #define LOG_DST_UPDATE 0

--- a/src/unum/speedtest/speedtest.c
+++ b/src/unum/speedtest/speedtest.c
@@ -659,13 +659,14 @@ void speedtest_perform()
     int limit = UTIL_ARRAY_SIZE(speedtests);
     for(i = 0; i < limit; ++i) {
         speedtests[i]();
+        // Let other threads have a turn.
+        sched_yield();
+        // Report intermediate results
         if(i != limit-1) {
             // Stream results except for the last iteration-- the results
             // will be uploaded after the test is over anyway.
             speedtest_upload_results_failfast();
         }
-        // Let other threads have a turn.
-        sched_yield();
     }
 
     // Deal with the various possible final states.

--- a/src/unum/support/linux_generic/support.h
+++ b/src/unum/support/linux_generic/support.h
@@ -17,6 +17,8 @@
 #ifndef _SUPPORT_H
 #define _SUPPORT_H
 
+// this module is not supported by linux_generic
+
 #define SUPPORT_LONG_PERIOD 0
 
 #define LOG_DST_SUPPORT 0

--- a/src/unum/unum.c
+++ b/src/unum/unum.c
@@ -312,7 +312,7 @@ static void print_usage(int argc, char *argv[])
     printf(" -s, --set-url-pfx            - custom 'http(s)://<host>' URL\n");
     printf("                                prefix\n");
 #endif //DEBUG
-    printf(" -m, --mode                   - set opertion mode\n");
+    printf(" -m, --mode                   - set operation mode\n");
 #ifdef FW_UPDATER_OPMODE
     printf("                                u[pdater]: firmware updater\n");
 #endif // FW_UPDATER_OPMODE

--- a/src/unum/util/linux_generic/util.h
+++ b/src/unum/util/linux_generic/util.h
@@ -36,9 +36,8 @@
 #include "../util_crashinfo.h"
 
 
-// This string is the device type ID, should be in sync with the server.
-// For Linux builds it comes from the make options since all the builds use
-// the same "linux_generic" MODEL ID.
+// This string is the hardware kind. It should be in sync with the server.
+// Usually it comes from the Makefile in the gcc invocation options
 //#define DEVICE_PRODUCT_NAME "hardware_type_here"
 
 // Graceful reboot command for the platform (if not defined

--- a/src/unum/wireless/wireless_iwinfo.c
+++ b/src/unum/wireless/wireless_iwinfo.c
@@ -196,7 +196,7 @@ int wt_iwinfo_get_noise(char *ifname, int *noise)
     return 0;
 }
 
-// Get transmit power offset (in dBm)
+// Get transmit power offset (in dBm, it is quite often not supported)
 // Returns: 0 if successful, negative if fails
 int wt_iwinfo_get_txpwr_offset(char *ifname, int *offset)
 {
@@ -208,7 +208,6 @@ int wt_iwinfo_get_txpwr_offset(char *ifname, int *offset)
     }
 
     if(iw->txpower_offset(ifname, offset) != 0) {
-        log_dbg("%s: failed to get tx power offset for %s\n", __func__, ifname);
         return -2;
     }
 


### PR DESCRIPTION
This PR contains updates from the internal agent since around the beginning of December. There isn't much to report, but here's what changed:

* Flexible `release_properties.json` generation - features listed in `files/features-common.txt` will be included in the json.
* Fixed an optimization in the LAN speedtest handler
* Adds a "crash_me" command for debug builds
* And two changes to keep the two projects in sync: 
  * Firmware updating isn't supported by the open source agent, but: Adds the ability to force a firmware update when triggered by the user on the dashboard.
  * Comment changes
