### PR TITLE
Bump version to 2019.2.0-snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the open source distribution of
 > Running the Unum agent requires a Minim Labs developer account. 
 > [Sign up for an account][3] on the Minim website.
 
-Unum is a closs-platform program and can be built and installed on
+Unum is a cross-platform program and can be built and installed on
 OpenWrt-compatible devices, as well as Linux x86_64, i386, and armhf 
 architectures.
 

--- a/dist/debian/changelog.base
+++ b/dist/debian/changelog.base
@@ -1,6 +1,9 @@
 unum-aio ($AGENT_VERSION) UNRELEASED; urgency=medium
 
-  * Add cloud config sending/receiving/updating
+  * Add support for Minim cloud config sending/receiving/applying
+  * Add crash_me command for debug builds
+  * Fix useless yield in speedtest intermediate result sending
+  * Fix iptables sequence number incrementing
 
  -- Tyler Sommer <tyler@minim.co>  Wed, 22 Jan 2019 12:26:34 -0700
 

--- a/dist/make_dotdeb.sh
+++ b/dist/make_dotdeb.sh
@@ -22,7 +22,7 @@ for arg in $@; do
     esac
 done
 
-VERSION_BASE="2019.1.1"
+VERSION_BASE="2019.2.0"
 VERSION_STABILITY="unstable"
 VERSION=${1:-"${VERSION_BASE}-snapshot"}
 

--- a/extras/docker/Dockerfile.build
+++ b/extras/docker/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-ARG unum_version=2019.1.1-snapshot
+ARG unum_version=2019.2.0-snapshot
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
This bumps the version to 2019.2.0-snapshot. Not intentionally following months of the year, but the addition of cloud config support and the openwrt_generic hardwarekind warrants something more than a patchlevel bump.