### PR TITLE
Ensure PATH in systemd unum.service is comprehensive

### DIFF
--- a/extras/linux_generic/etc/systemd/unum.service
+++ b/extras/linux_generic/etc/systemd/unum.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/opt/unum
-Environment=PATH=${PATH}:/opt/unum/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/unum/lib
+Environment=PATH=/bin:/usr/bin:/usr/local/bin:/sbin/:/usr/sbin:/usr/local/sbin:/opt/unum/bin LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/unum/lib
 ExecStart=/opt/unum/bin/unum --cfg-file /etc/opt/unum/config.json
 PIDFile=/var/run/unum-agent.pid
 


### PR DESCRIPTION
This PR takes care of some weirdness around the unum systemd service in .deb distributions where, for example, `bash` and `iptables` are not on the PATH.