### PR TITLE
Backport speedtest and related changes from upstream

### DIFF
--- a/src/unum/agent.c
+++ b/src/unum/agent.c
@@ -76,6 +76,10 @@ int agent_main(void)
         // should never reach this point
     }
 
+    // Log agent operation mode (it still can change in activate or
+    // when platform examines the config during init)
+    log("%s: opmode: \"%s\"\n", __func__, unum_config.opmode);
+
     // Initialize subsystems
     for(level = 1; level <= MAX_INIT_LEVEL; level++)
     {
@@ -90,6 +94,7 @@ int agent_main(void)
                 // should never reach this point
             }
         }
+        init_level_completed = level;
     }
     log_dbg("%s: Init done\n", __func__);
 

--- a/src/unum/http/http_common.h
+++ b/src/unum/http/http_common.h
@@ -117,12 +117,14 @@ http_rsp *http_get_no_retry(char *url, char *headers);
 // this is used to test speeds. returns 0 if successful
 // error otherwise.
 // Pass 0 as timeout_in_sec to disable the timeout completely.
-int http_download_test(char *url, long timeout_in_sec, size_t *size);
+int http_download_test(char *ifname, char *url,
+                       long timeout_in_sec, size_t *size);
 
 // Uploads random data to an endpoint to test the upload speed
 // returns 0 if successful, -1 otherwise.
 // Pass 0 as timeout_in_sec to disable the timeout completely.
-int http_upload_test(char *url, long timeout_in_sec, size_t *size);
+int http_upload_test(char *ifname, char *url,
+                     long timeout_in_sec, size_t *size);
 
 // Subsystem init function
 int http_init(int level);

--- a/src/unum/include/unum.h
+++ b/src/unum/include/unum.h
@@ -48,10 +48,10 @@
 #include <net/if.h>
 #include <poll.h>
 #include <unistd.h>
+#include <linux/types.h>
 #include <linux/reboot.h>
 #include <linux/filter.h>
 #include <linux/if_packet.h>
-#include <linux/virtio_net.h>
 #include <linux/sockios.h>
 #include <linux/rtnetlink.h>
 #include <sys/reboot.h>
@@ -127,6 +127,9 @@
 // suffix is monitor, agent, support, fw_update, etc.
 #define AGENT_PID_FILE_PREFIX "/var/run/unum"
 
+// Macro for checking the agent current operation mode flags
+#define IS_OPM(feature) (((feature) & unum_config.opmode_flags) != 0)
+
 // Default agent config path, platforms can override in platform.h.
 #ifndef UNUM_CONFIG_PATH
 #  define UNUM_CONFIG_PATH "/tmp/unum.conf"
@@ -139,7 +142,19 @@ typedef struct {
     unsigned int no_provision:1;   // no provisioning (no wait for cert/key)
     unsigned int no_conncheck:1;   // no connectivity check
     char *url_prefix;              // custom "http(s)://<host>" URL part
-    char *mode;                    // special op. mode <u[pdate]|s[upport]...>
+    char *mode;                    // special run mode <u[pdate]|s[upport]...>
+#define UNUM_OPMS_MD          "md" // managed device mode
+#define UNUM_OPMS_AP          "ap" // AP mode
+#define UNUM_OPMS_GW          "gw" // gateway mode
+#define UNUM_OPMS_MESH_11S_AP "mesh_11s_ap" // AP in ieee802.11s mesh mode
+#define UNUM_OPMS_MESH_11S_GW "mesh_11s_gw" // gateway in ieee802.11s mesh mode
+    char *opmode;                  // agent opmode string (above) <gw|ap|...>
+#define UNUM_OPM_AUTO     0x1  // can pick operating mode automatically
+#define UNUM_OPM_GW       0x2  // operating in gateway mode
+#define UNUM_OPM_AP       0x4  // operating in wireless AP mode
+#define UNUM_OPM_MD       0x8  // operating in managed device mode
+#define UNUM_OPM_MESH_11S 0x10 // operating in ieee802.11s mesh mode
+    int opmode_flags;              // opmode flags (above, used by IS_OPM(...))
     char *ca_file;                 // trusted CA file for CURL
     char *pid_fprefix;             // PID file prefix, e.g. "/var/run/unum"
     int telemetry_period;          // router telemetry reporting period
@@ -194,6 +209,9 @@ extern UNUM_CONFIG_t unum_config;
 // process, monitored process after being forked can examine it and log, report
 // to the server or just ignore it)
 extern UNUM_START_REASON_t process_start_reason;
+
+// The init level that we have executed all the init routines for
+extern int init_level_completed;
 
 
 // The function parses config from the file or from the server activate

--- a/src/unum/security/port_scan.c
+++ b/src/unum/security/port_scan.c
@@ -220,7 +220,7 @@ static int probe_ports(unsigned long scan_delay, unsigned long wait_time,
         unsigned char protocol;
         unsigned short tcp_length;
         struct tcphdr tcp;
-    } __attribute__((packed)) *psh; // pseudoheader for TCP checksum
+    } *psh; // pseudoheader for TCP checksum
     char pkt[(sizeof(struct pseudo_header) + 15) & (~0xf)]; // data buf
 
     // Set pointers to the pseudo and TCP header within the buffer
@@ -667,12 +667,26 @@ int cmd_port_scan(char *cmd, char *s, int s_len)
 #ifdef DEBUG
 void test_port_scan(void)
 {
-    char *jstr =
-        "[{\"mac\":\"00:0c:29:3b:b1:70\",\"ipv4\":\"192.168.0.100\","
-          "\"ports\":[\"80\", \"20-22\",\"443\"],"
-          "\"scan_delay\":200, \"wait_time\":1000},"
-         "{\"mac\":\"00:0c:29:f4:ae:07\",\"ipv4\":\"192.168.0.101\","
-          "\"ports\":[\"1-65535\"],\"retries\":0}]";
+    char mac1[20], mac2[20];
+    char ip1[20], ip2[20];
+    char jstr[512];
+
+    printf("Please enter MAC for scan destination one:\n");
+    scanf("%18s", mac1);
+    printf("Please enter IP for scan destination one:\n");
+    scanf("%16s", ip1);
+    printf("Please enter MAC for scan destination two:\n");
+    scanf("%18s", mac2);
+    printf("Please enter IP for scan destination two:\n");
+    scanf("%16s", ip2);
+    
+    sprintf(jstr, 
+            "[{\"mac\":\"%s\",\"ipv4\":\"%s\","
+            "\"ports\":[\"80\", \"20-22\",\"443\"],"
+            "\"scan_delay\":200, \"wait_time\":1000},"
+            "{\"mac\":\"%s\",\"ipv4\":\"%s\","
+            "\"ports\":[\"1-65535\"],\"retries\":0}]",
+            mac1, ip1, mac2, ip2);
 
     printf("Testing 'port_scan' command, JSON payload:\n%s\n", jstr);
     printf("Starting TPCAP...");

--- a/src/unum/security/port_scan.h
+++ b/src/unum/security/port_scan.h
@@ -39,7 +39,8 @@ typedef struct _PORT_SCAN_DEVICE {
 } PORT_SCAN_DEVICE_t;
 
 // The "port_scan" command processor.
-int cmd_port_scan(char *cmd, char *s, int s_len);
+// Note: declared weak so platforms not doing it do not have to stub
+int __attribute__((weak)) cmd_port_scan(char *cmd, char *s, int s_len);
 
 #ifdef DEBUG
 void test_port_scan(void);

--- a/src/unum/unum.c
+++ b/src/unum/unum.c
@@ -21,6 +21,10 @@ INIT_FUNC_t init_list[] = { INITLIST, NULL };
 // Array of init function names (matches the above)
 char *init_str_list[] = { INITSTRLIST, NULL };
 
+// The init level that we have executed all the init routines for
+int init_level_completed = 0;
+
+
 // Unum configuration context global structure
 UNUM_CONFIG_t unum_config = {
     .telemetry_period          = TELEMETRY_PERIOD,
@@ -33,6 +37,16 @@ UNUM_CONFIG_t unum_config = {
     .sysinfo_period            = SYSINFO_TELEMETRY_PERIOD,
     .ipt_period                = IPT_TELEMETRY_PERIOD,
     .config_path               = UNUM_CONFIG_PATH,
+#if defined(FEATURE_MANAGED_DEVICE)
+    .opmode                    = UNUM_OPMS_MD,
+    .opmode_flags              = UNUM_OPM_MD,
+#elif defined(FEATURE_LAN_ONLY)
+    .opmode                    = UNUM_OPMS_AP,
+    .opmode_flags              = UNUM_OPM_AP,
+#else  // Has both LAN & WAN and not a managed device
+    .opmode                    = UNUM_OPMS_GW,
+    .opmode_flags              = UNUM_OPM_AUTO | UNUM_OPM_GW,
+#endif // 
 };
 
 // long options table, we are using the option long name to encode
@@ -41,7 +55,7 @@ UNUM_CONFIG_t unum_config = {
 // 'n' - no argument option
 // 'c' - char string option
 // 'i' - takes an integer number
-// 'm' - mode change option
+// 'm' - run mode change option
 // the option scope:
 // 'o' - the option can be used in the command line only
 // 'c' - config option that can be in both command line and config file
@@ -60,16 +74,19 @@ static struct option long_options[] =
     {"no-provision\0nc",   no_argument,       NULL, 'p'},
     {"set-url-pfx\0cc",    required_argument, NULL, 's'},
 #endif // DEBUG
-#ifdef SUPPORT_OPMODE
+#ifdef SUPPORT_RUN_MODE
     {"support-period\0ic", required_argument, NULL, 'A'},
-#endif // SUPPORT_OPMODE
-#ifdef FW_UPDATER_OPMODE
+#endif // SUPPORT_RUN_MODE
+#ifdef FW_UPDATER_RUN_MODE
     {"fwupd-period\0ic",   required_argument, NULL, 'E'},
-#endif // FW_UPDATER_OPMODE
+#endif // FW_UPDATER_RUN_MODE
     {"pid-prefix\0cc",     required_argument, NULL, 'i'},
     {"trusted-ca\0cc",     required_argument, NULL, 'c'},
     {"mode\0mc",           required_argument, NULL, 'm'},
+    {"opmode\0ca",         required_argument, NULL, 'o'},
+#ifndef FEATURE_LAN_ONLY
     {"wan-if\0cc",         required_argument, NULL, 'w'},
+#endif // FEATURE_LAN_ONLY
     {"lan-if\0ca",         required_argument, NULL, 'l'},
     {"rtr-t-period\0ia",   required_argument, NULL, 'R'},
     {"tpcap-period\0ia",   required_argument, NULL, 'T'},
@@ -96,6 +113,20 @@ static char proc_pid_file[256] = "";
 // the reason for the start/re-start and in case of the restart due to
 // a failure the associated error information)
 UNUM_START_REASON_t process_start_reason;
+
+// Helper to open file with close on exec flag
+static int open_cloexec(char *name, int flags, int mode)
+{
+#ifdef O_CLOEXEC
+   int fd = open(name, flags | O_CLOEXEC, mode);
+#else  // !O_CLOEXEC
+   int fd = open(proc_pid_file, flags, mode);
+   if(fd != -1) {
+     fcntl(fd, F_SETFD, FD_CLOEXEC);
+   }
+#endif // O_CLOEXEC
+   return fd;
+}
 
 // Check that the process is not already running and create its PID
 // file w/ specified suffix.
@@ -140,11 +171,11 @@ int unum_handle_start(char *suffix)
         if(ii > 0) {
             sleep(AGENT_STARTUP_RETRY_DELAY);
         }
-        int fd = open(proc_pid_file, O_CREAT|O_EXCL|O_RDWR|O_CLOEXEC, 0660);
+        int fd = open_cloexec(proc_pid_file, O_CREAT | O_EXCL | O_RDWR, 0660);
         if(fd < 0)
         {
             // try to open for read/write if can't create the file
-            if((fd = open(proc_pid_file, O_RDWR|O_CLOEXEC)) < 0) {
+            if((fd = open_cloexec(proc_pid_file, O_RDWR, 0)) < 0) {
                 log("%s: can't %s PID file <%s>: %s\n",
                     __func__, "open", proc_pid_file, strerror(errno));
                 ret = -1;
@@ -312,24 +343,44 @@ static void print_usage(int argc, char *argv[])
     printf(" -s, --set-url-pfx            - custom 'http(s)://<host>' URL\n");
     printf("                                prefix\n");
 #endif //DEBUG
-    printf(" -m, --mode                   - set operation mode\n");
-#ifdef FW_UPDATER_OPMODE
+    printf(" -m, --mode                   - set custom run mode\n");
+#ifdef FW_UPDATER_RUN_MODE
     printf("                                u[pdater]: firmware updater\n");
-#endif // FW_UPDATER_OPMODE
-#ifdef SUPPORT_OPMODE
+#endif // FW_UPDATER_RUN_MODE
+#ifdef SUPPORT_RUN_MODE
     printf("                                s[upport]: support portal agent\n");
-#endif // SUPPORT_OPMODE
+#endif // SUPPORT_RUN_MODE
 #ifdef DEBUG
     printf("                                t[1|2|3...]: run test 1,2,3...\n");
     printf(" -p, --no-provision           - skip provisioning (no client\n");
     printf("                                cert in the requests)\n");
 #endif // DEBUG
+    printf(" -o, --opmode <mode_name>     - set unum agent operation mode\n");
+#if !defined(FEATURE_LAN_ONLY)
+    printf("                                gw: gateway (default)\n");
+#endif // !FEATURE_LAN_ONLY
+#if defined(FEATURE_AP_MODE) || defined(FEATURE_LAN_ONLY)
+    printf("                                ap: wireless AP\n");
+#endif // FEATURE_AP_MODE || FEATURE_LAN_ONLY
+#if defined(FEATURE_MANAGED_DEVICE)
+    printf("                                md: managed device\n");
+#endif // FEATURE_MANAGED_DEVICE
+#if defined(FEATURE_MESH_11S)
+# if !defined(FEATURE_LAN_ONLY)
+    printf("                                mesh_11s_gw: gw w/ 802.11s mesh\n");
+# endif // !FEATURE_LAN_ONLY
+# if defined(FEATURE_AP_MODE) || defined(FEATURE_LAN_ONLY)
+    printf("                                mesh_11s_ap: ap w/ 802.11s mesh\n");
+# endif // FEATURE_AP_MODE || FEATURE_LAN_ONLY
+#endif // FEATURE_MESH_11S
     printf(" -c, --trusted-ca <PATHNAME>  - trusted CAs file pathname\n");
     printf(" -l, --lan-if <IFNAME_LIST>   - custom LAN interface name(s)\n");
     printf("                                separated by comma or space,\n");
     printf("                                list the main LAN ifname first,\n");
     printf("                                example: -l \"eth0 eth1 ...\"\n");
+#ifndef FEATURE_LAN_ONLY
     printf(" -w, --wan-if <IFNAME>        - custom WAN interface name\n");
+#endif // FEATURE_LAN_ONLY
     printf(" --rtr-t-period <5-120>       - router telemetry reporting\n");
     printf("                                interval\n");
     printf(" --tpcap-period <15-120>      - devices telemetry reporting\n");
@@ -344,16 +395,16 @@ static void print_usage(int argc, char *argv[])
     printf("                                0: disable reporting\n");
     printf(" --sysinfo-period <0-...>     - sysinfo reporting interval\n");
     printf("                                0: disable reporting\n");
-#ifdef FW_UPDATER_OPMODE
+#ifdef FW_UPDATER_RUN_MODE
     printf(" --fwupd-period <60-...>      - firmware upgrade check time\n");
     printf("                                for \"-m updater\"\n");
 #endif //FW_UPDATER_MODE
-#ifdef SUPPORT_OPMODE
+#ifdef SUPPORT_RUN_MODE
     printf(" --support-period <%d-...>    - support connection attempt\n",
            SUPPORT_SHORT_PERIOD);
     printf("                                interval for \"-m support\"\n");
     printf("                                0: connect upon request only\n");
-#endif //SUPPORT_OPMODE
+#endif //SUPPORT_RUN_MODE
 }
 
 // Takes a list of interface names from the command line, separates them using
@@ -442,7 +493,7 @@ static int do_config_int(char opt_long, int optarg)
     // switched based off val returned by getopt
     switch(opt_long) 
     {
-#ifdef SUPPORT_OPMODE
+#ifdef SUPPORT_RUN_MODE
         case 'A':
             if(!unum_config.mode || *(unum_config.mode) != 's') {
                 status = -1;
@@ -454,8 +505,8 @@ static int do_config_int(char opt_long, int optarg)
                 status = -2;
             }
             break;
-#endif // SUPPORT_OPMODE
-#ifdef FW_UPDATER_OPMODE
+#endif // SUPPORT_RUN_MODE
+#ifdef FW_UPDATER_RUN_MODE
         case 'E':
             if(!unum_config.mode || *(unum_config.mode) != 'u') {
                 status = -3;
@@ -465,7 +516,7 @@ static int do_config_int(char opt_long, int optarg)
                 unum_config.fw_update_check_period = optarg;
             }
             break;
-#endif //FW_UPDATER_OPMODE
+#endif //FW_UPDATER_RUN_MODE
         case 'R':
             if(optarg < 5 || optarg > 120) {
                 status = -5;
@@ -561,6 +612,14 @@ static int do_config_char(char opt_long, char *optarg)
             unum_config.wan_ifname[sizeof(unum_config.wan_ifname) - 1] = 0;
             unum_config.wan_ifcount = 1;
             break;                
+        case 'o':
+            status = util_set_opmode(optarg);
+            if(status < 0) {
+                // Give status offset to avoid overlap with other errors here
+                status -= 10;
+                break;
+            }
+            break;
         default:
             status = -3;
             break;
@@ -579,12 +638,12 @@ static int do_config_mode(char *optarg)
         default:
             status = -1;
             // drop down (in case nothing is defined)
-#ifdef FW_UPDATER_OPMODE
+#ifdef FW_UPDATER_RUN_MODE
         case 'u':
-#endif // FW_UPDATER_OPMODE
-#ifdef SUPPORT_OPMODE
+#endif // FW_UPDATER_RUN_MODE
+#ifdef SUPPORT_RUN_MODE
         case 's':
-#endif // SUPPORT_OPMODE
+#endif // SUPPORT_RUN_MODE
 #ifdef DEBUG
         case 't':
 #endif // DEBUG
@@ -595,12 +654,12 @@ static int do_config_mode(char *optarg)
     return status;
 }
 
-// The function parses config from the file or from the server activate
-// response. The file (or the data buffer) must be a valid JSON and
-// only contain the key-value pairs with the keys same as the long options.
-// file_or_data - filename or JSON data (if at_activate is TRUE)
+// The function parses config JSON from the file or from the server activate
+// response. The JSON can only contain the key-value pairs with the keys same 
+// as the command line long options.
 // at_activate - TRUE if passing null-terminated JSON string received from
 //               server's activate response, FALSE if passing config file name
+// file_or_data - filename or JSON data (if at_activate is TRUE)
 // Note: the log() macro prints to stdout until the log subsystem
 //       is initialized
 int parse_config(int at_activate, char *file_or_data)
@@ -686,6 +745,11 @@ int parse_config(int at_activate, char *file_or_data)
                     log("%s: invalid value: %s for: %s\n",
                         __func__, (int_val ? "TRUE" : "FALSE"), key);
                     status = -3;
+                    break;
+                }
+                if(at_activate) {
+                    log("%s: turned %s %s at activate\n",
+                        __func__, key, (int_val ? "on" : "off"));
                 }
                 break;
 	
@@ -703,6 +767,11 @@ int parse_config(int at_activate, char *file_or_data)
                     log("%s: invalid value: %d for: %s\n",
                         __func__, int_val, key);
                     status = -5;
+                    break;
+                }
+                if(at_activate) {
+                    log("%s: set %s to %d at activate\n",
+                        __func__, key, int_val);
                 }
                 break;
 
@@ -721,6 +790,15 @@ int parse_config(int at_activate, char *file_or_data)
                     log("%s: invalid value: %s for: %s\n",
                         __func__, str_val, key);
                     status = -7;
+                    break;
+                }
+                // Bump up refcount for the string value since it might be
+                // stored as pointer (typical since we reuse cmdline handlers).
+                // The value stays allocated for the lifetime of the process.
+                json_incref(json_val);
+                if(at_activate) {
+                    log("%s: set %s to %s at activate\n",
+                        __func__, key, str_val);
                 }
                 break;
 
@@ -732,7 +810,7 @@ int parse_config(int at_activate, char *file_or_data)
         }
     }
 
-    // Free up the JSON resources    
+    // Free up unreferenced JSON resources
     json_decref(root);
 
     return status;
@@ -829,7 +907,7 @@ static int parse_cmdline(int pick_cfg_file_name)
             // mode option
             case 'm':
                 if(do_config_mode(optarg) != 0) {
-                    log("%s: invalid operation mode \"%s\"\n",
+                    log("%s: invalid run mode \"%s\"\n",
                         __func__, optarg);
                     status = -6;
                 }
@@ -880,21 +958,21 @@ int main(int argc, char *argv[])
         do_daemon();
     }
 
-    // Check and run code for the requested operation mode
+    // Check and run code for the requested run mode
     if(unum_config.mode)
     {
         switch(*(unum_config.mode))
         {
-#ifdef FW_UPDATER_OPMODE
+#ifdef FW_UPDATER_RUN_MODE
             case 'u':
                 // Until sure that updater never fails allow to monitor it.
                 process_monitor(LOG_DST_UPDATE_MONITOR, "updater_monitor");
                 return fw_update_main();
-#endif // FW_UPDATER_OPMODE
-#ifdef SUPPORT_OPMODE
+#endif // FW_UPDATER_RUN_MODE
+#ifdef SUPPORT_RUN_MODE
             case 's':
                 return support_main();
-#endif // SUPPORT_OPMODE
+#endif // SUPPORT_RUN_MODE
 #ifdef DEBUG
             case 't':
                 // Crash handling test requires monitoring
@@ -921,13 +999,13 @@ int main(int argc, char *argv[])
 
     // Disable access to the logs the agent should not be touching
     unsigned long mask = (
-#ifdef FW_UPDATER_OPMODE
+#ifdef FW_UPDATER_RUN_MODE
       (1 << LOG_DST_UPDATE)         |
       (1 << LOG_DST_UPDATE_MONITOR) |
-#endif // FW_UPDATER_OPMODE
-#ifdef SUPPORT_OPMODE
+#endif // FW_UPDATER_RUN_MODE
+#ifdef SUPPORT_RUN_MODE
       (1 << LOG_DST_SUPPORT)        |
-#endif // SUPPORT_OPMODE
+#endif // SUPPORT_RUN_MODE
       0
     );
     set_disabled_log_dst_mask(mask);

--- a/src/unum/util/linux_generic/util_platform.c
+++ b/src/unum/util/linux_generic/util_platform.c
@@ -77,15 +77,20 @@ int util_platform_init(int level)
                 lan_up = TRUE;
             }
 
-#ifndef AP_MODE
-            if(util_net_dev_is_up(GET_MAIN_WAN_NET_DEV()))
-            {
-                log("%s: WAN is up\n", __func__);
+#ifndef FEATURE_LAN_ONLY
+            if(IS_OPM(UNUM_OPM_AP)) {
+                // In AP mode set the flag to prevent further checking
                 wan_up = TRUE;
+            } else {
+                // In non-AP mode do real check if WAN is up
+                if (util_net_dev_is_up(GET_MAIN_WAN_NET_DEV())) {
+                    log("%s: WAN is up\n", __func__);
+                    wan_up = TRUE;
+                }
             }
-#else  // !AP_MODE
+#else  // !FEATURE_LAN_ONLY
             wan_up = TRUE;
-#endif // !AP_MODE
+#endif // !FEATURE_LAN_ONLY
 
             log("lan_up=%d... wan_up=%d\n", lan_up, wan_up);
             if(!lan_up || !wan_up) {
@@ -122,7 +127,7 @@ int util_platform_enum_ifs(int flags, UTIL_IF_ENUM_CB_t f, void *data)
         failed += (ret == 0 ? 0 : 1);
     }
 
-#ifndef AP_MODE
+#ifndef FEATURE_LAN_ONLY
     // We only support 1 WAN interface.
     // Note: This might need to be updated to deal with
     //       PPPoE and VPN-based WAN connections properly
@@ -130,7 +135,7 @@ int util_platform_enum_ifs(int flags, UTIL_IF_ENUM_CB_t f, void *data)
         ret = f(GET_MAIN_WAN_NET_DEV(), data);
         failed += (ret == 0 ? 0 : 1);
     }
-#endif // !AP_MODE
+#endif // !FEATURE_LAN_ONLY
 
     return failed;
 }

--- a/src/unum/util/util_common.h
+++ b/src/unum/util/util_common.h
@@ -125,6 +125,12 @@ void util_factory_reset(void);
 // does not define FACTORY_RESET_CMD)
 int __attribute__((weak)) util_platform_factory_reset(void);
 
+
+// Populate auth_info_key Auth Info Key
+// For Gl-inet B1300 it is serial number
+// For now (03/17/19), for all other devices, auth_info_key is not updated
+void __attribute__((weak)) util_get_auth_info_key(char *auth_info_key, int max_key_len);
+
 // Return uptime in specified fractions of the second (rounded to the low)
 unsigned long long util_time(unsigned int fraction);
 
@@ -175,8 +181,25 @@ unsigned int util_hash(void *dptr, int len);
 // str - ptr to the string to clean up
 void util_cleanup_str(char *str);
 
+// Configure the agent to the specified operation mode
+// opmode - the operation mode string pointer
+// Returns: 0 - success, negative - error setting the opmode
+// Note: this function is called from command line procesing routines
+//       before any init is done (i.e. even the log msgs would go to stdout)
+int util_set_opmode(char *opmode);
+
 // Optional platform init function
 int __attribute__((weak)) util_platform_init(int level);
+
+// Optional platform operation mode change handler, called if the 
+// opmode is changing after the INIT_LEVEL_SETUP is complete
+// (i.e. at activate). The function does not have to set the new flags
+// or modify the mode string in unum_config, just do platform specific
+// canges and return 0 for the common code to finish making changes.
+// old_flags - current opmode flags
+// new_flags - new opmode flags
+// Returns: 0 - ok, negative - can't accept the new flags
+int __attribute__((weak)) platform_change_opmode(int old_flags, int new_flags);
 
 // Subsystem init function
 int util_init(int level);

--- a/src/unum/util/util_common.mk
+++ b/src/unum/util/util_common.mk
@@ -17,7 +17,6 @@
 # Add code file(s)
 OBJECTS += ./util/util.o ./util/jobs.o ./util/util_event.o ./util/util_net.o
 OBJECTS += ./util/util_json.o ./util/util_timer.o ./util/util_crashinfo.o
-OBJECTS += ./util/util_stubs.o
 OBJECTS += ./util/$(MODEL)/util_platform.o ./util/util_stubs.o
 
 # Add subsystem initializer function

--- a/src/unum/util/util_json.c
+++ b/src/unum/util/util_json.c
@@ -191,6 +191,59 @@ static json_t *util_tpl_to_json_val(JSON_VAL_TPL_t *val, char *key, int *perr)
     return jval;
 }
 
+// The functioon sets value pointer in the JSON object template
+// for the specified template entry. It suppors setting only the
+// pointers for values that are not functions.
+// Returns: 0 - success, negative - key not found or unsupported type
+int util_json_obj_tpl_set_val_ptr(JSON_OBJ_TPL_t tpl, char *key, void *ptr)
+{
+    JSON_KEYVAL_TPL_t *kv;
+    int err = 0;
+
+    // Loop through all keyvalue pairs of the template and find what we
+    // are asked to change.
+    int found = FALSE;
+    for(kv = tpl; kv && kv->key; kv++)
+    {
+        if(strcmp(kv->key, key) != 0) {
+            continue;
+        }
+        found = TRUE;
+        JSON_VAL_TPL_t *val = &kv->val;
+        switch(val->type) {
+            case JSON_VAL_STR:
+                val->s = (char *)ptr;
+                break;
+            case JSON_VAL_PINT:
+                val->pi = (int *)ptr;
+                break;
+            case JSON_VAL_PUL:
+                val->pul = (unsigned long *)ptr;
+                break;
+            case JSON_VAL_PUINT:
+                val->pui = (unsigned int *)ptr;
+                break;
+            case JSON_VAL_PJINT:
+                val->pji = (json_int_t *)ptr;
+                break;
+            case JSON_VAL_OBJ:
+                val->o = (struct _JSON_KEYVAL_TPL *)ptr;
+                break;
+            default:
+                log("%s: key %s value type %d is not supported\n",
+                    __func__, key, val->type);
+                err = -2;
+                break;
+        }
+    }
+    if(!found) {
+        log("%s: key %s is not found\n", __func__, key);
+        err = -1;
+    }
+
+    return err;
+}
+
 // Function for building libjansson JSON object from a template.
 // The created object must be freed by json_decref() libjansson function.
 json_t *util_tpl_to_json_obj(JSON_OBJ_TPL_t tpl)

--- a/src/unum/util/util_json.h
+++ b/src/unum/util/util_json.h
@@ -89,6 +89,11 @@ typedef struct _JSON_KEYVAL_TPL {
 // The last keyval pair must hould key == NULL
 typedef JSON_KEYVAL_TPL_t JSON_OBJ_TPL_t[];
 
+// The functioon sets value pointer in the JSON object template
+// for the specified template entry. It suppors setting only the
+// pointers for values that are not functions.
+// Returns: 0 - success, negative - key not found or unsupported type
+int util_json_obj_tpl_set_val_ptr(JSON_OBJ_TPL_t tpl, char *key, void *ptr);
 // Function for building libjansson JSON object from a template
 // The created object must be freed by json_decref() libjansson function.
 json_t *util_tpl_to_json_obj(JSON_OBJ_TPL_t tpl);

--- a/src/unum/util/util_net.h
+++ b/src/unum/util/util_net.h
@@ -172,6 +172,11 @@ typedef struct _UDP_PAYLOAD {
 // Returns: TRUE - interface is up, FALSE - down or error
 int util_net_dev_is_up(char *ifname);
 
+// Checks if the interface reports link UP
+// ifname - the interface name
+// Returns: TRUE - interface link is up, FALSE - down or error
+int util_net_dev_link_is_up(char *ifname);
+
 // Enumerite the list of the IP interfaces. For each interface a caller's
 // callback is invoked until all the interfaces are enumerated.
 // Returns: 0 - success, number of times the callback has failed
@@ -205,7 +210,8 @@ int util_get_ipcfg(char *dev, DEV_IP_CFG_t *ipcfg);
 char *util_device_mac();
 
 // Get the IPv4 address (as a string) of a network device.
-// The buf length should be at least INET_ADDRSTRLEN bytes.
+// The buf length should be at least INET_ADDRSTRLEN bytes
+// If buf is NULL it is not used.
 // Returns 0 if successful, error code if fails.
 int util_get_ipv4(char *dev, char *buf);
 
@@ -243,6 +249,13 @@ unsigned short util_ip_cksum(unsigned short *addr, int len);
 // Returns: 0 - if gw_ip is populated w/ the gateway IP address,
 //          negative error code otherwise
 int util_get_ipv4_gw(IPV4_ADDR_t *gw_ip);
+
+// Get default route outbound interface name
+// ifnam - ptr to the buffer that receives the interface name
+//         the buffer has to be at least IFNAMSIZ long
+// Returns: 0 - if gw_ip is populated w/ the gateway IP address,
+//          negative error code otherwise
+int util_get_ipv4_gw_oif(char *ifnam);
 
 // Find a monitored LAN interface for sending traffic to the specified IP
 // address. Parameters:


### PR DESCRIPTION
This is a partial backport of upstream changes from the internal codebase. 

The goal of this PR is to introduce the updates/fixes related to `http` and `speedtest` modules that have been made in recent months. Specifically, this fixes several issues related to uninitialized memory and buffer overruns.

- [x] PR in minim-openwrt-feed to test with OpenWrt based platforms: MinimSecure/minim-openwrt-feed#6