### PR TITLE
util_time fixes and improvements

### DIFF
--- a/rules/asus_map_ac1300.mk
+++ b/rules/asus_map_ac1300.mk
@@ -61,12 +61,12 @@ TARGET_CPPFLAGS_unum := \
         -I$(TARGET_LIBS)/libssl/include \
         -I$(TARGET_LIBS)/libcurl/include
 
-TARGET_LDFLAGS_unum := -ldl -lm \
-	-L$(TARGET_LIBS)/libnvram/lib/ -l:libnvram.so \
-	-L$(TARGET_LIBS)/libshared/lib/ -l:libshared.so \
+TARGET_LDFLAGS_unum := -ldl -lm -lrt \
 	-L$(TARGET_LIBS)/libcurl/lib/ -l:libcurl.so \
 	-L$(TARGET_LIBS)/libssl/lib/ -l:libssl.so \
-	-L$(TARGET_LIBS)/libssl/lib/ -l:libcrypto.so
+	-L$(TARGET_LIBS)/libssl/lib/ -l:libcrypto.so \
+	-L$(TARGET_LIBS)/libnvram/lib/ -l:libnvram.so \
+	-L$(TARGET_LIBS)/libshared/lib/ -l:libshared.so
         
 ### GDB
 GDB_VERSION := gdb-7.11

--- a/rules/asus_map_ac1700.mk
+++ b/rules/asus_map_ac1700.mk
@@ -61,13 +61,13 @@ TARGET_CPPFLAGS_unum := \
         -I$(TARGET_LIBS)/libssl/include \
         -I$(TARGET_LIBS)/libcurl/include
 
-TARGET_LDFLAGS_unum := -ldl -lm \
-	-L$(TARGET_LIBS)/libnvram/lib/ -l:libnvram.so \
-	-L$(TARGET_LIBS)/libshared/lib/ -l:libshared.so \
+TARGET_LDFLAGS_unum := -ldl -lm -lrt \
 	-L$(TARGET_LIBS)/libcurl/lib/ -l:libcurl.so \
 	-L$(TARGET_LIBS)/libssl/lib/ -l:libssl.so \
-	-L$(TARGET_LIBS)/libssl/lib/ -l:libcrypto.so
-        
+	-L$(TARGET_LIBS)/libssl/lib/ -l:libcrypto.so \
+	-L$(TARGET_LIBS)/libnvram/lib/ -l:libnvram.so \
+	-L$(TARGET_LIBS)/libshared/lib/ -l:libshared.so
+ 
 ### GDB
 GDB_VERSION := gdb-7.11
 TARGET_VARS_gdb := VERSION=$(GDB_VERSION)

--- a/src/unum/util/util_common.h
+++ b/src/unum/util/util_common.h
@@ -162,8 +162,7 @@ void __attribute__((weak)) util_get_auth_info_key(char *auth_info_key, int max_k
 int  __attribute__((weak)) util_get_mac_list(char *mac_list, int max_len);
 
 // Return uptime in specified fractions of the second (rounded to the low)
-// Note: it's not uptime or montonic for some platforms, NTP makes it jump
-//       at least when intially sets the time.
+// Note: it's typically (but not necessarily) the same as uptime
 unsigned long long util_time(unsigned int fraction);
 
 // Sleep the specified number of milliseconds

--- a/src/unum/util/util_timer.c
+++ b/src/unum/util/util_timer.c
@@ -250,6 +250,7 @@ static void timer_test2(TIMER_PARAM_t *p)
 // Test timers functionality
 void test_timers(void)
 {
+    int i, err, ecode;
     TIMER_PARAM_t tp;
 
     // Init timers subsystem
@@ -260,6 +261,64 @@ void test_timers(void)
     }
 
     printf("%s: Starting\n", __func__);
+
+    printf("%s: Clock functions:\n", __func__);
+    printf("%s:   util_time(1) => %llu\n", __func__, util_time(1));
+    for(i = 0; i < 16; i++) {
+        struct timespec t;
+        char clock_name[128];
+        // Clock IDs up to Linux 3.14.x
+        switch(i) {
+            case CLOCK_REALTIME:
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_REALTIME");
+                break;
+            case CLOCK_MONOTONIC:
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_MONOTONIC");
+                break;
+            case CLOCK_PROCESS_CPUTIME_ID:
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_PROCESS_CPUTIME_ID");
+                break;
+            case CLOCK_THREAD_CPUTIME_ID:
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_THREAD_CPUTIME_ID");
+                break;
+            case 4: // CLOCK_MONOTONIC_RAW
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_MONOTONIC_RAW");
+                break;
+            case 5: // CLOCK_REALTIME_COARSE
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_REALTIME_COARSE");
+                break;
+            case 6: // CLOCK_MONOTONIC_COARSE
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_MONOTONIC_COARSE");
+                break;
+            case 7: // CLOCK_BOOTTIME
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_BOOTTIME");
+                break;
+            case 8: // CLOCK_REALTIME_ALARM
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_REALTIME_ALARM");
+                break;
+            case 9: // CLOCK_BOOTTIME_ALARM
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_BOOTTIME_ALARM");
+                break;
+            case 10: // CLOCK_SGI_CYCLE
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_SGI_CYCLE");
+                break;
+            case 11: // CLOCK_TAI
+                snprintf(clock_name, sizeof(clock_name), "CLOCK_TAI");
+                break;
+            default:
+                snprintf(clock_name, sizeof(clock_name), "%d", i);
+        }
+        err = clock_gettime(i, &t);
+        ecode = errno;
+        printf("%s:   clock_gettime(%.25s, ...) => %s",
+               __func__, clock_name, ((err == 0) ? "Ok" : "Error"));
+        if(err == 0) {
+            printf(" %lu:%lu\n", t.tv_sec, t.tv_nsec);
+        } else {
+            printf(" %s\n", strerror(ecode));
+        }
+    }
+
     printf("%s: Setup timer1 in 10, timer2 in 15sec, no new thread\n",
            __func__);
     util_timer_set(10000, "timer1", timer_test1, NULL, FALSE);


### PR DESCRIPTION
This pull request contains 3 commits:
1. 40a8c03 asus: fix for clock jump on startup -> bugfix
2. 3b0690e util: use CLOCK_MONOTONIC_RAW for util_time if available -> use clock not affected by adjtime(x) adjustments if kernel supports it
3. 80a8254 util_timers: try all 16 clock IDs before timers test -> print out values returned by all clock supported by kernel before running the timers subsystem tests
