### PR TITLE
b1300: add edns0 feature flag for correctness

### DIFF
--- a/files/lede_generic/features-gl_b1300.txt
+++ b/files/lede_generic/features-gl_b1300.txt
@@ -2,3 +2,4 @@ mesh_11s
 ap_mode
 mac_filter
 mesh_batman
+edns0_content_filter


### PR DESCRIPTION
We are handling the ends0 configuration for this device by editing server config code, but adding this flag for completeness on this platform. 