### PR TITLE
Activate fw_update conncheck fixes

### DIFF
--- a/src/unum/activate/activate.c
+++ b/src/unum/activate/activate.c
@@ -165,9 +165,6 @@ static char *router_activate_json(char *my_mac)
             start_reason = NULL;
     }
 
-    // Reset reason code
-    process_start_reason.code = UNUM_START_REASON_UNKNOWN;
-
     JSON_OBJ_TPL_t tpl_tbl_crash_info = {
       { "type",       {.type = JSON_VAL_STR, { .s = crash_type_ptr }}},
       { "location",   {.type = JSON_VAL_STR, { .s = crash_location_ptr }}},

--- a/src/unum/conncheck/conncheck_common.h
+++ b/src/unum/conncheck/conncheck_common.h
@@ -11,9 +11,9 @@
 // Add random startup delay up to CONNCHECK_START_DELAY seconds
 #define CONNCHECK_START_DELAY 0
 
-// How long to allow the cloud connectivity to fail before restarting
-// the comunication checker (for now just restart the agent), in sec.
-// This should is also used as the connection checker watchdog timeout.
+// How long to allow the cloud connectivity to fail before restarting the
+// connectivity checker (for now just restart the agent), in sec. This
+// constant is also used as the connectivity checker watchdog timeout.
 #define CONNCHECK_OFFLINE_RESTART 600
 
 // Max allowed time diff (in sec) before considering it an error and adjust
@@ -50,7 +50,9 @@
 #define CONNCHECK_NO_DNS_FILE "/var/unum_dns_error"
 
 // How many times to try DNS test (retrying only on prtial success)
-#define CONNCHECK_DNS_TRIES 3
+// Note: it doesn't help much to retry more than once, that one
+//       retry allows calling res_init() that helps in some cases
+#define CONNCHECK_DNS_TRIES 2
 
 
 // IDs for conncheck state (cstate)

--- a/src/unum/fw_update/fw_update_common.h
+++ b/src/unum/fw_update/fw_update_common.h
@@ -11,10 +11,15 @@
 // Number of retries if unable to do forced upgrade
 #define FORCE_FW_UPDATE_RETRIES 6
 
-// default suffix for download firmware image URL (allows to
+// Default suffix for download firmware image URL (allows to
 // specify extra parameter for requesting specific platfrom
 // image), override in the platform header
 #define FIRMWARE_RELEASE_INFO_URL_SUFFIX ""
+
+// How long to allow the cloud connectivity to fail before restarting
+// the updater process (it runs under updater monitor, so we can use
+// util_restart()), in sec.
+#define UPDATER_OFFLINE_RESTART 600
 
 // Firmware updater main entry point
 int fw_update_main(void);

--- a/src/unum/http/http_curl.h
+++ b/src/unum/http/http_curl.h
@@ -23,7 +23,7 @@
 #define REQ_CONNECT_TIMEOUT    20
 #define REQ_API_TIMEOUT        30
 #define REQ_API_TIMEOUT_SHORT  5
-#define REQ_FILE_TIMEOUT       480
+#define REQ_FILE_TIMEOUT       1200
 
 // Timeouts used in common code for setting up watchdog
 // MAX time for HTTP REST API operations

--- a/src/unum/include/monitor.h
+++ b/src/unum/include/monitor.h
@@ -31,4 +31,11 @@
 // pid_suffix - suffix for the PID file of the monitoring process
 void process_monitor(int log_dst, char *pid_suffix);
 
+// The function is intended to be called by the agent process that might be run
+// under the supervision of the process monitor. It returns TRUE if the
+// supervision is NOT detected, FALSE otherwise. It returns a negative value in
+// case of an error. It is able to detect if the monitor process was killed and
+// replaced with a debugger session.
+int is_process_unmonitored(void);
+
 #endif // _MONITOR_H

--- a/src/unum/util/util.c
+++ b/src/unum/util/util.c
@@ -33,8 +33,9 @@ void util_shutdown(int err)
 // reason - see enum unum_start_reason
 void util_restart(int reason)
 {
-    log("Terminating unum %s, restart requested\n", VERSION);
-    if(unum_config.unmonitored || unum_config.mode != NULL) {
+    log("Terminating unum %s, restart requested, reson %d\n", VERSION, reason);
+    if(is_process_unmonitored()) {
+        // ToDo: handle self restart
         log("The process is not monitored, restart manually\n");
     }
     agent_exit(reason);

--- a/src/unum/util/util_common.h
+++ b/src/unum/util/util_common.h
@@ -57,6 +57,7 @@ enum unum_start_reason {
     UNUM_START_REASON_REBOOT_FAIL,  // failed to reboot
     UNUM_START_REASON_SERVER,       // restart command from server
     UNUM_START_REASON_FW_START_FAIL,// failed to start FW updater
+    UNUM_START_REASON_FW_CONN_FAIL, // failed to reach release server
     UNUM_START_REASON_KILL,         // terminated by kill (set by monitor)
 };
 


### PR DESCRIPTION
conncheck: DNS troubleshooter tweaks
fw_update: restart if fails to connect for too long
activate: never clear the start reason code
monitor: improved util_restart()
http: increased file download timeout to 20min