### PR TITLE
Persistent logs support.

### DIFF
--- a/src/unum/include/unum.h
+++ b/src/unum/include/unum.h
@@ -49,6 +49,7 @@
 #include <signal.h>
 #include <jansson.h>
 #include <getopt.h>
+#include <libgen.h>
 
 #ifdef USE_OPEN_SSL
 #  include <openssl/crypto.h>

--- a/src/unum/log/log.c
+++ b/src/unum/log/log.c
@@ -58,17 +58,6 @@ static int get_log_file_name(LOG_CONFIG_t *lc, char *log_file)
     char *dir;
 
     memset(log_file, 0, LOG_MAX_PATH);
-    if (lc->name == NULL) {
-        // No logfile needed
-        // Eg. STDOUT
-        return 1;
-    }
-    strncpy(log_file, lc->name, LOG_MAX_PATH);
-
-    if (lc->flags & LOG_FLAG_TTY) {
-        // For console
-        return 2;
-    }
     // Check if the prefix file exists
     if (!util_path_exists(LOG_PREFIX_FILE)) {
         // Prefix file does n't exist. Use defaults.

--- a/src/unum/log/log_common.h
+++ b/src/unum/log/log_common.h
@@ -21,6 +21,13 @@
 // Max log file pathsname length the code will deal with
 #define LOG_MAX_PATH 128
 
+// A file containing the Prefix(directory).
+// All log files (example /var/log/unum.log)
+// will be prefixed with the content from this filename.
+#ifdef PERSISTENT_FS_DIR_PATH
+#define LOG_PREFIX_FILE PERSISTENT_FS_DIR_PATH"/unum_prefix_file.txt"
+#endif
+
 // Enum of available log output destinations
 typedef enum {
     LOG_DST_STDOUT,  // logging to stdout (should be first)
@@ -54,10 +61,12 @@ typedef enum {
 // The 16 lower bits are common flags. The upper 16bits are
 // platform specific flags (LOG_FLAG_FILE, LOG_FLAG_STDOUT...
 // see log_platform.h).
-#define LOG_FLAG_INIT_DONE 0x0001 // The entry has been initialized
-#define LOG_FLAG_INIT_FAIL 0x0002 // The log entry init has failed
-#define LOG_FLAG_MUTEX     0x0004 // The entry requre mutex protextion
-#define LOG_FLAG_INIT_MSG  0x0008 // Log the agent startup info at init
+#define LOG_FLAG_INIT_DONE    0x0001 // The entry has been initialized
+#define LOG_FLAG_INIT_FAIL    0x0002 // The log entry init has failed
+#define LOG_FLAG_MUTEX        0x0004 // The entry requre mutex protextion
+#define LOG_FLAG_INIT_MSG     0x0008 // Log the agent startup info at init
+#define LOG_FLAG_INIT_PER     0x0010 // Log the agent on persistent storage
+#define LOG_FLAG_LOG_CHANGED  0x0020 // Log file changed.
 
 // Logging control & configurtion structure (defines the elements of
 // the logging config array of LOG_DST_MAX size).
@@ -69,6 +78,7 @@ typedef struct {
     size_t cut_size;   // cut to the size (in case exceeding max_size too much)
     unsigned int max;  // files to keep when rotating (in addition to the log)
     FILE *f;           // current log file pointer
+    char log_file[LOG_MAX_PATH];
 } LOG_CONFIG_t;
 
 // Logging configuration and control structure (see log_platform.c)

--- a/src/unum/log/log_common.h
+++ b/src/unum/log/log_common.h
@@ -58,15 +58,15 @@ typedef enum {
 // log names from Y to LOG_ROTATE_CLEANUP_MAX)
 #define LOG_ROTATE_CLEANUP_MAX 9
 
+#define LOG_FILE_PREFIX "/var/log/"
+
 // The 16 lower bits are common flags. The upper 16bits are
 // platform specific flags (LOG_FLAG_FILE, LOG_FLAG_STDOUT...
 // see log_platform.h).
-#define LOG_FLAG_INIT_DONE    0x0001 // The entry has been initialized
-#define LOG_FLAG_INIT_FAIL    0x0002 // The log entry init has failed
-#define LOG_FLAG_MUTEX        0x0004 // The entry requre mutex protextion
-#define LOG_FLAG_INIT_MSG     0x0008 // Log the agent startup info at init
-#define LOG_FLAG_INIT_PER     0x0010 // Log the agent on persistent storage
-#define LOG_FLAG_LOG_CHANGED  0x0020 // Log file changed.
+#define LOG_FLAG_INIT_DONE 0x0001 // The entry has been initialized
+#define LOG_FLAG_INIT_FAIL 0x0002 // The log entry init has failed
+#define LOG_FLAG_MUTEX     0x0004 // The entry requre mutex protextion
+#define LOG_FLAG_INIT_MSG  0x0008 // Log the agent startup info at init
 
 // Logging control & configurtion structure (defines the elements of
 // the logging config array of LOG_DST_MAX size).
@@ -78,7 +78,6 @@ typedef struct {
     size_t cut_size;   // cut to the size (in case exceeding max_size too much)
     unsigned int max;  // files to keep when rotating (in addition to the log)
     FILE *f;           // current log file pointer
-    char log_file[LOG_MAX_PATH];
 } LOG_CONFIG_t;
 
 // Logging configuration and control structure (see log_platform.c)

--- a/src/unum/util/util.c
+++ b/src/unum/util/util.c
@@ -394,6 +394,57 @@ int util_system(char *cmd, unsigned int timeout, char *pid_file)
     return ret;
 }
 
+// Function to check if a directory exists
+// dir - Name of the directory
+// Returns true if dir exists and also a directory
+// False otherwise
+int util_directory_exists(char *dir)
+{
+    struct stat st;
+    if (stat(dir, &st) == 0 && S_ISDIR(st.st_mode)) {
+        return TRUE;
+    } else {
+        return FALSE;
+    }
+}
+
+// Function to check if a file exists
+// fname - Name of the file
+// Returns true if filename exists
+// False otherwise
+int util_file_exists(char *fname)
+{
+    struct stat st;
+    if (stat(fname, &st) == 0) {
+        return TRUE;
+    } else {
+        return FALSE;
+    }
+}
+
+// Create a directory and all the subdirectories on the way
+// dirname - Full path of the directory
+// mode - mode
+void util_mkdir_rec(const char *dirname, mode_t mode)
+{
+    char *tmp;
+    char subdir[256];
+    int len = strlen(dirname);
+
+    tmp = strchr(dirname, '/');
+    while(tmp != NULL) {
+        memset(subdir, 0, sizeof(subdir));
+        strncpy(subdir, dirname, tmp - dirname);
+        mkdir(subdir, mode);
+        if (tmp > dirname + len - 1) {
+            //Check the boundaries
+            break;
+        }
+        tmp = strchr(tmp + 1, '/');
+    }
+    mkdir(dirname, mode);
+}
+
 // Call cmd in shell and capture its stdout in a buffer.
 // Returns: negative if fails to start cmd (see errno for the error code), the
 //          length of the captured info (excluding terminating 0) if success.

--- a/src/unum/util/util_common.h
+++ b/src/unum/util/util_common.h
@@ -240,6 +240,15 @@ int util_system_wcb(char *cmd,
 // the PID of the running process while it is executing.
 int util_system(char *cmd, unsigned int timeout, char *pid_file);
 
+// Function to check if a directory exists
+int util_directory_exists(char *dir);
+
+// Function to check if a file exists
+int util_file_exists(char *fname);
+
+// Create directories recursively
+void util_mkdir_rec(const char *dirname, mode_t mode);
+
 // Call cmd in shell and capture its stdout in a buffer.
 // Returns: negative if fails to start cmd (see errno for the error code), the
 //          length of the captured info (excluding terminating 0) if success.

--- a/src/unum/util/util_common.h
+++ b/src/unum/util/util_common.h
@@ -240,14 +240,8 @@ int util_system_wcb(char *cmd,
 // the PID of the running process while it is executing.
 int util_system(char *cmd, unsigned int timeout, char *pid_file);
 
-// Function to check if a directory exists
-int util_directory_exists(char *dir);
-
-// Function to check if a file exists
-int util_file_exists(char *fname);
-
 // Create directories recursively
-void util_mkdir_rec(const char *dirname, mode_t mode);
+int util_mkdir_rec(const char *dirname, mode_t mode);
 
 // Call cmd in shell and capture its stdout in a buffer.
 // Returns: negative if fails to start cmd (see errno for the error code), the


### PR DESCRIPTION
This solution does n't need any platform specific changes.

Agent checks the file unum_prefix_file.txt under persistent directory and if it exists reads its contents. This file contains the prefix (persistent storage directories).
When this file unum_prefix_file.txt exists, the agents prefixes all the log files (example. /var/log/unum.log etc) with prefixes and creates appropriate directories. And all the log files will be created on persistent storage.
Names for console and stdout are untouched based on the flags and filenames.