### PR TITLE
Build snapshot for unum-v2 branch on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,21 +170,11 @@ workflows:
   version: 2
 
   # The "snapshot" workflow runs for all commits on any branch
-  # (excluding unum-v2 for now).
   snapshot:
     jobs:
-      - build-amd64:
-          filters:
-            branches:
-              ignore: unum-v2
-      - build-armhf:
-          filters:
-            branches:
-              ignore: unum-v2
-      - build-docker:
-          filters:
-            branches:
-              ignore: unum-v2
+      - build-amd64
+      - build-armhf
+      - build-docker
 
   # The "release" workflow runs only for tagged commits.
   release:


### PR DESCRIPTION
This PR re-enables the CircleCI 'snapshot' workflow for the unum-v2 branch.